### PR TITLE
Add automated cookie report fix workflow

### DIFF
--- a/.github/prompts/fix-cookie-reports.md
+++ b/.github/prompts/fix-cookie-reports.md
@@ -1,0 +1,152 @@
+# Fix Cookie Rejection Reports
+
+## Role & Objective
+
+You are an automated agent that fixes cookie popup rejection failures reported by users of the Reject Cookies browser extension. Read CLAUDE.md first — it contains the full architecture, provider list, selector conventions, and patterns you must follow.
+
+## Environment Variables
+
+These are available in your environment:
+
+- `COOKIE_API_BASE` — Base URL for the cookie reports API (no trailing slash)
+- `COOKIE_API_TOKEN` — Bearer token for API authentication
+- `RUN_DATE` — Date string for this run (e.g., `2026-02-24`), used in branch naming
+- `SNAPSHOT_COUNT` — Number of snapshots available (informational)
+
+## Step 1 — Fetch the Report Manifest
+
+Fetch the list of sites to fix:
+
+```
+GET ${COOKIE_API_BASE}/api/reports/latest-manifest
+Authorization: Bearer ${COOKIE_API_TOKEN}
+```
+
+The response is a JSON array of report objects. Each report has at minimum:
+- `id` — Report ID (used for marking fixed and fetching snapshots)
+- `url` — The site URL where the cookie popup wasn't rejected
+- `cmp_provider` — The detected CMP provider name, or `"unknown"` / `null` if unidentified
+
+If the manifest is empty or the request fails, log the reason and exit cleanly — do not create a branch or PR.
+
+## Step 2 — Analyze Each Site
+
+For each report in the manifest, fetch its HTML snapshot:
+
+```
+GET ${COOKIE_API_BASE}/api/reports/{id}/snapshot
+Authorization: Bearer ${COOKIE_API_TOKEN}
+```
+
+The response is the raw HTML of the page as captured by a headless browser.
+
+Analyze the HTML to determine what fix is needed:
+
+### Known CMP (`cmp_provider` is set and not "unknown")
+
+The CMP platform is already identified. Check our existing detection selectors and rejection selectors against the snapshot HTML:
+- Are the detection selectors (from `src/checks.ts`) present in the HTML?
+- Are the rejection button selectors (from `src/rejectFlows/`) present in the HTML?
+- Identify which selectors are broken or missing, and find the correct replacement selectors in the HTML
+
+### Unknown CMP (`cmp_provider` is "unknown" or null)
+
+Search the HTML for common CMP patterns:
+- Known container IDs/classes from our provider list (check if an existing provider matches but wasn't detected)
+- Common CMP framework signatures: OneTrust, CookieBot, Didomi, Quantcast, Sourcepoint, etc.
+- Generic cookie consent patterns: elements with "cookie", "consent", "gdpr" in IDs or classes
+
+If you identify the platform, treat it as a known CMP fix. If it's a genuinely new platform, you'll add a new provider.
+
+## Step 3 — Implement Code Changes
+
+Group fixes by provider to minimize file changes. Follow these rules strictly:
+
+### For existing providers (selector updates)
+- Update detection selectors in `src/checks.ts`
+- Update rejection button selectors in `src/rejectFlows/` (either `index.ts` or the provider's dedicated file)
+- Do NOT change the provider name in `src/providers.ts`
+
+### For new providers
+Follow the pattern in CLAUDE.md — "Adding a New Cookie Provider":
+1. Add a detection function in `src/checks.ts`
+2. Add a rejection function in `src/rejectFlows/index.ts` (or a new file for complex cases like shadow DOM)
+3. Register in `commonCookiePopupChecks` array in `src/providers.ts`
+
+### Selector quality rules
+- Prefer `getElementById` for known IDs
+- Use `querySelector` with data attributes or class prefixes for elements without stable IDs
+- Use `[id^="prefix"]` for dynamic IDs with stable prefixes
+- Never use `nth-child`, deeply nested paths, or hash-based class names
+- Verify selectors actually exist in the HTML snapshot before using them
+
+### If a report is unfixable
+Some reports may not be actionable — the HTML may not contain enough information, or the CMP may use techniques we can't handle (e.g., new closed shadow DOM patterns). Skip these and note them for the PR body.
+
+## Step 4 — Verify
+
+After making all code changes, run:
+
+```bash
+npm run lint
+npm run build
+```
+
+Both must pass. If lint reports auto-fixable issues, run `npm run lint` (it auto-fixes). If build fails, investigate and fix the error. If a specific provider's changes cause the failure, revert that provider's changes and exclude it from the fixed set.
+
+## Step 5 — Mark Reports Fixed
+
+For each report that was successfully addressed (code changes made and verified), call:
+
+```
+PATCH ${COOKIE_API_BASE}/api/reports/mark-fixed
+Authorization: Bearer ${COOKIE_API_TOKEN}
+Content-Type: application/json
+
+{ "report_ids": [1, 2, 3] }
+```
+
+Only include IDs for reports where you actually made and verified code changes. Do not include skipped reports.
+
+## Step 6 — Version Bump
+
+If any code changes were made, increment the patch version in `public/manifest.json`. For example, `0.0.5` becomes `0.0.6`. Only bump once regardless of how many providers were fixed.
+
+## Step 7 — Commit, Push, and Create PR
+
+Create a branch, commit, push, and open a PR:
+
+1. **Branch name:** `fix/cookie-reports-${RUN_DATE}`
+2. **Stage only modified/new files explicitly** — do not use `git add .` or `git add -A`
+3. **Commit message:** Concise summary like `Fix cookie rejection for [site1], [site2]` or `Add new provider [name] and fix [site]`
+4. **Push** the branch to origin
+5. **Create a PR** with this body format:
+
+```markdown
+## Summary
+Automated fixes for cookie popup rejection failures reported on ${RUN_DATE}.
+
+## Changes
+| Site | CMP | Selectors Added/Changed | Report Count |
+|------|-----|------------------------|--------------|
+| example.com | onetrust | Updated reject button selector | 3 |
+
+## Skipped Reports
+<!-- List any reports that couldn't be fixed and why, or "None" -->
+
+## Verification
+- [ ] `npm run lint` passes
+- [ ] `npm run build` passes
+- [ ] Detection selectors verified against HTML snapshots
+- [ ] Rejection selectors verified against HTML snapshots
+
+## Version
+Bumped manifest version from X.X.X to Y.Y.Y
+```
+
+## Error Handling
+
+- **No fixable reports** — Exit cleanly with a log message. Do not create a branch or PR.
+- **Partial fixes** — Create the PR with whatever works. List skipped reports in the PR body with reasons.
+- **API failures** — Log the error and exit. Do not create a partial PR without data.
+- **Lint/build failures after changes** — Attempt to fix. If a specific provider's changes are the cause, revert those changes and remove that provider from the fixed set. Only create a PR if at least one fix survives.

--- a/.github/prompts/fix-cookie-reports.md
+++ b/.github/prompts/fix-cookie-reports.md
@@ -110,7 +110,7 @@ Only include IDs for reports where you actually made and verified code changes. 
 
 ## Step 6 — Version Bump
 
-If any code changes were made, increment the patch version in `public/manifest.json`. For example, `0.0.5` becomes `0.0.6`. Only bump once regardless of how many providers were fixed.
+If any code changes were made, increment the patch version in `public/manifest.json`. For example, `0.0.5` becomes `0.0.6`. Only bump once regardless of how many providers were fixed. After committing (in Step 7), tag the commit with the same version prefixed with `v` (e.g., `git tag v0.0.6`). Push the tag along with the branch — this triggers the release workflow.
 
 ## Step 7 — Commit, Push, and Create PR
 
@@ -119,8 +119,9 @@ Create a branch, commit, push, and open a PR:
 1. **Branch name:** `fix/cookie-reports-${RUN_DATE}`
 2. **Stage only modified/new files explicitly** — do not use `git add .` or `git add -A`
 3. **Commit message:** Concise summary like `Fix cookie rejection for [site1], [site2]` or `Add new provider [name] and fix [site]`
-4. **Push** the branch to origin
-5. **Create a PR** with this body format:
+4. **Tag** the commit with the new version: `git tag v<new_version>` (e.g., `git tag v0.0.6`)
+5. **Push** the branch and tag to origin: `git push -u origin <branch> --follow-tags`
+6. **Create a PR** with this body format:
 
 ```markdown
 ## Summary

--- a/.github/workflows/fix-cookie-reports.yml
+++ b/.github/workflows/fix-cookie-reports.yml
@@ -38,4 +38,6 @@ jobs:
           SNAPSHOT_COUNT: ${{ github.event.client_payload.snapshot_count }}
         run: |
           claude --print --dangerously-skip-permissions \
+            --model claude-opus-4-6 \
+            --max-turns 75 \
             "$(cat .github/prompts/fix-cookie-reports.md)"

--- a/.github/workflows/fix-cookie-reports.yml
+++ b/.github/workflows/fix-cookie-reports.yml
@@ -1,0 +1,41 @@
+name: Fix Cookie Reports
+
+on:
+  repository_dispatch:
+    types: [snapshots_ready]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fix-reports:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run Claude Code to fix cookie reports
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          COOKIE_API_TOKEN: ${{ secrets.COOKIE_API_TOKEN }}
+          COOKIE_API_BASE: ${{ vars.COOKIE_API_BASE }}
+          RUN_DATE: ${{ github.event.client_payload.run_date }}
+          SNAPSHOT_COUNT: ${{ github.event.client_payload.snapshot_count }}
+        run: |
+          claude --print --dangerously-skip-permissions \
+            "$(cat .github/prompts/fix-cookie-reports.md)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist
 /node_modules
+.claude


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with full project architecture, provider registry, selector conventions, and contributor guidance
- Add GitHub Actions workflow (`fix-cookie-reports.yml`) triggered by `repository_dispatch` that runs Claude Code headlessly to fix cookie rejection failures from user reports
- Add structured prompt file (`.github/prompts/fix-cookie-reports.md`) that guides the agent through fetching report manifests, analyzing HTML snapshots, implementing selector fixes, and opening a PR

## Changes
- **`CLAUDE.md`** — Project documentation for Claude Code: architecture overview, provider table, rejection strategy, edge case patterns, selector conventions, and step-by-step guide for adding new providers
- **`.github/workflows/fix-cookie-reports.yml`** — `repository_dispatch` (`snapshots_ready`) workflow that checks out the repo, installs deps, and runs Claude Code with the prompt file. All secrets/vars referenced via GitHub encrypted secrets.
- **`.github/prompts/fix-cookie-reports.md`** — 7-step prompt: fetch manifest, analyze snapshots, implement fixes, lint/build, mark reports fixed via API, bump version, commit/push/PR
- **`.gitignore`** — Add `.claude` directory

## Test plan
- [ ] Trigger manually with `gh api repos/mitch292/reject-cookies/dispatches -f event_type=snapshots_ready -f 'client_payload={"run_date":"2026-02-24","snapshot_count":1}'`
- [ ] Verify workflow appears in Actions tab and runs successfully
- [ ] Verify Claude Code fetches manifest, analyzes snapshots, and opens a fix PR (or exits cleanly if no fixable reports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)