### PR TITLE
Enable tag fetching in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Check for version tag
         id: check-tag


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` defaults `fetch-tags` to `false`, so the version tag check was always finding nothing
- Adds `fetch-tags: true` to the checkout step

## Follow-up
After merging, will move the `v0.0.6` tag to main HEAD to trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)