### PR TITLE
Add automated version tagging to release workflow

### DIFF
--- a/.github/prompts/fix-cookie-reports.md
+++ b/.github/prompts/fix-cookie-reports.md
@@ -107,7 +107,7 @@ Statuses:
 
 ## Step 6 — Version Bump
 
-If any code changes were made, increment the patch version in `public/manifest.json`. For example, `0.0.5` becomes `0.0.6`. Only bump once regardless of how many providers were fixed. After committing (in Step 7), tag the commit with the same version prefixed with `v` (e.g., `git tag v0.0.6`). Push the tag along with the branch — this triggers the release workflow.
+If any code changes were made, increment the patch version in `public/manifest.json`. For example, `0.0.5` becomes `0.0.6`. Only bump once regardless of how many providers were fixed. Do not create a git tag — tagging is handled automatically by the workflow after this step.
 
 ## Step 7 — Commit, Push, and Create PR
 
@@ -116,9 +116,8 @@ Create a branch, commit, push, and open a PR:
 1. **Branch name:** `fix/cookie-reports-${RUN_DATE}`
 2. **Stage only modified/new files explicitly** — do not use `git add .` or `git add -A`
 3. **Commit message:** Concise summary like `Fix cookie rejection for [site1], [site2]` or `Add new provider [name] and fix [site]`
-4. **Tag** the commit with the new version: `git tag v<new_version>` (e.g., `git tag v0.0.6`)
-5. **Push** the branch and tag to origin: `git push -u origin <branch> --follow-tags`
-6. **Create a PR** with this body format:
+4. **Push** the branch to origin: `git push -u origin <branch>`
+5. **Create a PR** with this body format:
 
 ```markdown
 ## Summary

--- a/.github/workflows/fix-cookie-reports.yml
+++ b/.github/workflows/fix-cookie-reports.yml
@@ -41,3 +41,25 @@ jobs:
             --model claude-opus-4-6 \
             --max-turns 75 \
             "$(cat .github/prompts/fix-cookie-reports.md)"
+
+      - name: Tag version if branch was pushed
+        run: |
+          # Only tag if the agent created a new branch with commits
+          BRANCH=$(git branch --show-current)
+          if [ "$BRANCH" = "main" ]; then
+            echo "Still on main — agent did not create a branch. Skipping tag."
+            exit 0
+          fi
+
+          VERSION=$(jq -r .version public/manifest.json)
+          TAG="v${VERSION}"
+
+          # Skip if this tag already exists
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists. Skipping."
+            exit 0
+          fi
+
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Tagged and pushed $TAG"


### PR DESCRIPTION
## Summary
- Moves git tagging from the Claude Code agent prompt into a dedicated workflow step that runs deterministically after the agent finishes
- Removes tagging instructions from the agent prompt since it's now handled by the workflow

## Test plan
- [ ] Trigger a `snapshots_ready` dispatch and verify the workflow creates and pushes a version tag after the agent commits
- [ ] Verify the release workflow picks up the new tag and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)